### PR TITLE
[FIX] 프래그먼트 생성자 이슈 및 job 중복 관리

### DIFF
--- a/presentation/src/main/java/com/preonboarding/presentation/view/detail/DetailFragment.kt
+++ b/presentation/src/main/java/com/preonboarding/presentation/view/detail/DetailFragment.kt
@@ -10,14 +10,14 @@ import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
-import com.preonboarding.domain.model.EditState
-import com.preonboarding.domain.model.MODE
-import com.preonboarding.domain.model.ReviewUiState
+import com.preonboarding.presentation.view.review.EditState
 import com.preonboarding.presentation.R
 import com.preonboarding.presentation.common.base.BaseFragment
 import com.preonboarding.presentation.common.shared.setOnThrottleClickListener
 import com.preonboarding.presentation.databinding.FragmentDetailBinding
+import com.preonboarding.presentation.view.review.MODE
 import com.preonboarding.presentation.view.review.ReviewDialog
+import com.preonboarding.presentation.view.review.ReviewUiState
 import com.preonboarding.presentation.view.review.ReviewValidationDialog
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch

--- a/presentation/src/main/java/com/preonboarding/presentation/view/detail/DetailFragment.kt
+++ b/presentation/src/main/java/com/preonboarding/presentation/view/detail/DetailFragment.kt
@@ -91,7 +91,7 @@ class DetailFragment : BaseFragment<FragmentDetailBinding>(R.layout.fragment_det
     }
 
     private fun showValidationDialog(mode: MODE) {
-        val dialog = ReviewValidationDialog(mode)
+        val dialog = ReviewValidationDialog.newInstance(mode)
         dialog.show(requireActivity().supportFragmentManager, "ValidationDialog")
     }
 

--- a/presentation/src/main/java/com/preonboarding/presentation/view/detail/DetailViewModel.kt
+++ b/presentation/src/main/java/com/preonboarding/presentation/view/detail/DetailViewModel.kt
@@ -2,13 +2,13 @@ package com.preonboarding.presentation.view.detail
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.preonboarding.domain.model.EditState
-import com.preonboarding.domain.model.MODE
+import com.preonboarding.presentation.view.review.EditState
 import com.preonboarding.domain.model.Review
-import com.preonboarding.domain.model.ReviewUiState
 import com.preonboarding.domain.usecase.DeleteReviewUseCase
 import com.preonboarding.domain.usecase.GetReviewListUseCase
 import com.preonboarding.domain.usecase.UploadReviewUseCase
+import com.preonboarding.presentation.view.review.MODE
+import com.preonboarding.presentation.view.review.ReviewUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.*

--- a/presentation/src/main/java/com/preonboarding/presentation/view/detail/DetailViewModel.kt
+++ b/presentation/src/main/java/com/preonboarding/presentation/view/detail/DetailViewModel.kt
@@ -10,10 +10,10 @@ import com.preonboarding.domain.usecase.DeleteReviewUseCase
 import com.preonboarding.domain.usecase.GetReviewListUseCase
 import com.preonboarding.domain.usecase.UploadReviewUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-
 
 //TODO 영화제목 받아와야함
 @HiltViewModel
@@ -31,6 +31,8 @@ class DetailViewModel @Inject constructor(
 
     private val _selectedReview = MutableStateFlow(Review())
     val selectedReview = _selectedReview.asStateFlow()
+
+    private var getReviewListJob: Job? = null
 
     var reviewBuffer = Review()
 
@@ -55,7 +57,8 @@ class DetailViewModel @Inject constructor(
 
     // 영화제목 받아와야함
     fun setMovieList(title: String) {
-        viewModelScope.launch {
+        getReviewListJob?.cancel()
+        getReviewListJob = viewModelScope.launch {
             getReviewListUseCase(title).stateIn(
                 viewModelScope,
                 SharingStarted.Lazily,
@@ -64,7 +67,6 @@ class DetailViewModel @Inject constructor(
                 _reviewList.emit(it)
             }
         }
-
     }
 
     // 영화제목 받아와야함

--- a/presentation/src/main/java/com/preonboarding/presentation/view/review/EditState.kt
+++ b/presentation/src/main/java/com/preonboarding/presentation/view/review/EditState.kt
@@ -1,4 +1,4 @@
-package com.preonboarding.domain.model
+package com.preonboarding.presentation.view.review
 
 data class EditState(
     val isEditable: Boolean = true,

--- a/presentation/src/main/java/com/preonboarding/presentation/view/review/ReviewBindingAdapter.kt
+++ b/presentation/src/main/java/com/preonboarding/presentation/view/review/ReviewBindingAdapter.kt
@@ -9,7 +9,6 @@ import androidx.databinding.BindingAdapter
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.resource.bitmap.CenterCrop
 import com.bumptech.glide.load.resource.bitmap.RoundedCorners
-import com.preonboarding.domain.model.EditState
 
 @BindingAdapter("bindUri")
 fun ImageView.bindUri(uri: String?) {

--- a/presentation/src/main/java/com/preonboarding/presentation/view/review/ReviewDialog.kt
+++ b/presentation/src/main/java/com/preonboarding/presentation/view/review/ReviewDialog.kt
@@ -15,7 +15,6 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.google.android.material.snackbar.Snackbar
 import com.preonboarding.domain.model.Review
-import com.preonboarding.domain.model.ReviewUiState
 import com.preonboarding.presentation.R
 import com.preonboarding.presentation.common.base.BaseDialogFragment
 import com.preonboarding.presentation.common.shared.setOnThrottleClickListener

--- a/presentation/src/main/java/com/preonboarding/presentation/view/review/ReviewUiState.kt
+++ b/presentation/src/main/java/com/preonboarding/presentation/view/review/ReviewUiState.kt
@@ -1,4 +1,4 @@
-package com.preonboarding.domain.model
+package com.preonboarding.presentation.view.review
 
 sealed class ReviewUiState {
 

--- a/presentation/src/main/java/com/preonboarding/presentation/view/review/ReviewValidationDialog.kt
+++ b/presentation/src/main/java/com/preonboarding/presentation/view/review/ReviewValidationDialog.kt
@@ -7,6 +7,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.Window
+import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Lifecycle
@@ -21,10 +22,17 @@ import com.preonboarding.presentation.view.detail.DetailViewModel
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
-class ReviewValidationDialog(private val selectedMode: MODE) :
+class ReviewValidationDialog() :
     BaseDialogFragment<DialogReviewValidataionBinding>(R.layout.dialog_review_validataion) {
 
     private val reviewViewModel: DetailViewModel by activityViewModels()
+    private var selectedMode: MODE? = null
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        (arguments?.get(KEY_MODE) as? MODE).let {
+            selectedMode = it
+        }
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -59,10 +67,12 @@ class ReviewValidationDialog(private val selectedMode: MODE) :
         }
         binding.apply {
             btnValidationCheck.setOnClickListener {
-                reviewViewModel.checkPasswd(
-                    binding.etPasswordCheck.text.toString(),
-                    selectedMode
-                )
+                selectedMode?.let {
+                    reviewViewModel.checkPasswd(
+                        binding.etPasswordCheck.text.toString(),
+                        it
+                    )
+                }
             }
             btnValidationCancel.setOnClickListener {
                 dismiss()
@@ -70,4 +80,13 @@ class ReviewValidationDialog(private val selectedMode: MODE) :
         }
     }
 
+    companion object {
+        fun newInstance(mode: MODE): ReviewValidationDialog {
+            return ReviewValidationDialog().apply {
+                arguments = bundleOf(KEY_MODE to mode)
+            }
+        }
+
+        const val KEY_MODE: String = "key_mode"
+    }
 }

--- a/presentation/src/main/java/com/preonboarding/presentation/view/review/ReviewValidationDialog.kt
+++ b/presentation/src/main/java/com/preonboarding/presentation/view/review/ReviewValidationDialog.kt
@@ -13,8 +13,6 @@ import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
-import com.preonboarding.domain.model.MODE
-import com.preonboarding.domain.model.ReviewUiState
 import com.preonboarding.presentation.R
 import com.preonboarding.presentation.common.base.BaseDialogFragment
 import com.preonboarding.presentation.databinding.DialogReviewValidataionBinding


### PR DESCRIPTION
## 🔥 관련 이슈

## 🔥 PR Point
- 프래그먼트 생성자에 직접 파라미터를 넘겨주지 않고 기본 생성자에 번들을 넘겨주는 방식으로 수정
- DeatilViewModel에서 제목이 바뀌면 Job이 계속 남아있는것을 취소함

